### PR TITLE
Pyinstaller

### DIFF
--- a/kivy_reloader/app.py
+++ b/kivy_reloader/app.py
@@ -259,7 +259,10 @@ if platform != "android":
                 self.build_root_and_add_to_window()
 
                 self.apply_state(self.state)  # TODO
-                if self.HOT_RELOAD_ON_PHONE:
+                #can't hot reload on windows directly -- need WSL
+                if platform == "win":
+                    Logger.warning("Reloader: Reloading on Android requires WSL installation: https://kivyschool.com/kivy-reloader-WindowsWSL/")
+                elif self.HOT_RELOAD_ON_PHONE:
                     self.send_app_to_phone()
             except Exception as e:
                 import traceback

--- a/kivy_reloader/config.py
+++ b/kivy_reloader/config.py
@@ -2,7 +2,7 @@ import os
 from typing import Any, List
 
 import toml
-
+import sys
 
 class Config:
     def __init__(self):
@@ -29,7 +29,8 @@ class Config:
             "SERVICE_NAMES",
             "NO_AUDIO",
         ]
-        self._load_config()
+        if not hasattr(sys, "_MEIPASS"):
+            self._load_config()
 
     def _load_config(self):
         if os.path.exists(self.config_file):

--- a/kivy_reloader/utils.py
+++ b/kivy_reloader/utils.py
@@ -1,76 +1,49 @@
-import os
+import trio
+from colorama import Fore, Style, init
 
-from kivy.lang import Builder
-from kivy.utils import platform
+from kivy_reloader.config import config
 
-from .config import config
-
-base_dir = os.getcwd()
-
-
-def load_kv_path(path):
-    """
-    Loads a kv file from a path
-    """
-    kv_path = os.path.join(base_dir, path)
-    if kv_path in Builder.files:
-        Builder.unload_file(kv_path)
-
-    if kv_path not in Builder.files:
-        Builder.load_file(kv_path)
+red = Fore.RED
+green = Fore.GREEN
+yellow = Fore.YELLOW
+white = Fore.WHITE
+init(autoreset=True)
 
 
-def get_auto_reloader_paths():
-    """
-    Returns a list of paths to watch for changes,
-    based on the config.py file
-    """
-
-    def create_path_tuples(paths, recursive):
-        return [(os.path.join(base_dir, x), {"recursive": recursive}) for x in paths]
-
-    non_recursive_paths = (
-        config.WATCHED_FILES + config.WATCHED_FOLDERS + config.FULL_RELOAD_FILES
-    )
-    recursive_paths = config.WATCHED_FOLDERS_RECURSIVELY
-    if platform == 'win':
-        return create_path_tuples(non_recursive_paths, False) + create_path_tuples(
-            recursive_paths, True
-        )
-    else:
-        return create_path_tuples(non_recursive_paths, True) + create_path_tuples(
-            recursive_paths, True
-        )
+async def connect_to_server(IP):
+    try:
+        PORT = 8050
+        print(f"Connecting to IP: {green}{IP}{white} and PORT: {green}{config.PORT}")
+        with trio.move_on_after(1):
+            client_socket = await trio.open_tcp_stream(IP, PORT)
+            return client_socket
+    except Exception as e:
+        print(f"{red}Error: {e}")
+        return None
 
 
+async def send_app():
+    print("*" * 50)
+    print(green + "Connecting to smartphone...")
+    for IP in config.PHONE_IPS:
+        client_socket = await connect_to_server(IP)
+        if not client_socket:
+            print(f"{yellow}Couldn't connect to smartphone")
+            return
+        print(f"{yellow} Phone connected successfully: {IP}")
+        print(f"\n{green}Sending app to smartphone...")
+        CHUNK_SIZE = 4096
+        with open(
+            "app_copy.zip",
+            "rb",
+        ) as myzip:
+            for chunk in iter(lambda: myzip.read(CHUNK_SIZE), b""):
+                print("Sending chunk")
+                await client_socket.send_all(chunk)
+        print(green + "Finished sending app!")
+    print("\n")
+    print(yellow + f"Sent app to {len(config.PHONE_IPS)} smartphone(s)")
+    print("*" * 50)
 
 
-def find_kv_files_in_folder(folder):
-    kv_files = []
-    for root, _, files in os.walk(os.path.join(base_dir, folder)):
-        for file in files:
-            if file.endswith(".kv"):
-                kv_files.append(os.path.join(root, file))
-    return kv_files
-
-
-def get_kv_files_paths():
-    """
-    Given the folders on WATCHED_FOLDERS and WATCHED_FOLDERS_RECURSIVELY,
-    returns a list of all the kv files paths
-    """
-    KV_FILES = []
-
-    for folder in config.WATCHED_FOLDERS:
-        for file_name in os.listdir(folder):
-            if file_name.endswith(".kv"):
-                KV_FILES.append(os.path.join(base_dir, f"{folder}/{file_name}"))
-
-    for folder in config.WATCHED_FOLDERS_RECURSIVELY:
-        for file_name in find_kv_files_in_folder(folder):
-            KV_FILES.append(file_name)
-
-    # Removing duplicates
-    KV_FILES = list(set(KV_FILES))
-
-    return KV_FILES
+trio.run(send_app)

--- a/kivy_reloader/utils.py
+++ b/kivy_reloader/utils.py
@@ -1,49 +1,102 @@
-import trio
-from colorama import Fore, Style, init
+import os
 
-from kivy_reloader.config import config
+from kivy.lang import Builder
+from kivy.utils import platform
+from kivy.resources import resource_add_path, resource_find
+from .config import config
+import sys
+import pathlib
+import logging
 
-red = Fore.RED
-green = Fore.GREEN
-yellow = Fore.YELLOW
-white = Fore.WHITE
-init(autoreset=True)
-
-
-async def connect_to_server(IP):
-    try:
-        PORT = 8050
-        print(f"Connecting to IP: {green}{IP}{white} and PORT: {green}{config.PORT}")
-        with trio.move_on_after(1):
-            client_socket = await trio.open_tcp_stream(IP, PORT)
-            return client_socket
-    except Exception as e:
-        print(f"{red}Error: {e}")
-        return None
+logging.basicConfig(
+    level=logging.INFO,
+    format="%(asctime)s - %(levelname)s - %(message)s",
+)
+base_dir = os.getcwd()
 
 
-async def send_app():
-    print("*" * 50)
-    print(green + "Connecting to smartphone...")
-    for IP in config.PHONE_IPS:
-        client_socket = await connect_to_server(IP)
-        if not client_socket:
-            print(f"{yellow}Couldn't connect to smartphone")
-            return
-        print(f"{yellow} Phone connected successfully: {IP}")
-        print(f"\n{green}Sending app to smartphone...")
-        CHUNK_SIZE = 4096
-        with open(
-            "app_copy.zip",
-            "rb",
-        ) as myzip:
-            for chunk in iter(lambda: myzip.read(CHUNK_SIZE), b""):
-                print("Sending chunk")
-                await client_socket.send_all(chunk)
-        print(green + "Finished sending app!")
-    print("\n")
-    print(yellow + f"Sent app to {len(config.PHONE_IPS)} smartphone(s)")
-    print("*" * 50)
+def load_kv_path(path):
+    """
+    Loads a kv file from a path
+    """
+    if hasattr(sys, "_MEIPASS"):
+        resource_add_path(sys._MEIPASS)
+        test_path = pathlib.Path(path)
+        try:
+        #     look with extra root path appended to sys._MEIP0ASS
+            if str(test_path.parent) != ".":
+                meipass_path = pathlib.Path(sys._MEIPASS) / test_path.parent
+            resource_add_path(meipass_path)
+            logging.info(f"resource_find {meipass_path}, {test_path.name}")
+            kv_path = resource_find(test_path.name)
+        except:
+        #     last resort: do a naive search with resource find
+            kv_path = resource_find(path)
+            logging.info(f"kv path might be a duplicate, please double check {path}, {kv_path}")
+
+    else:
+        kv_path = os.path.join(base_dir, path)
+    print("what is kv path now?", kv_path, path)
+    if kv_path is None:
+        logging.error(f"failed to load kv path: {path}")
+    if kv_path in Builder.files:
+        Builder.unload_file(kv_path)
+
+    if kv_path not in Builder.files:
+        Builder.load_file(kv_path)
 
 
-trio.run(send_app)
+def get_auto_reloader_paths():
+    """
+    Returns a list of paths to watch for changes,
+    based on the config.py file
+    """
+
+    def create_path_tuples(paths, recursive):
+        return [(os.path.join(base_dir, x), {"recursive": recursive}) for x in paths]
+
+    non_recursive_paths = (
+        config.WATCHED_FILES + config.WATCHED_FOLDERS + config.FULL_RELOAD_FILES
+    )
+    recursive_paths = config.WATCHED_FOLDERS_RECURSIVELY
+    if platform == 'win':
+        return create_path_tuples(non_recursive_paths, False) + create_path_tuples(
+            recursive_paths, True
+        )
+    else:
+        return create_path_tuples(non_recursive_paths, True) + create_path_tuples(
+            recursive_paths, True
+        )
+
+
+
+
+def find_kv_files_in_folder(folder):
+    kv_files = []
+    for root, _, files in os.walk(os.path.join(base_dir, folder)):
+        for file in files:
+            if file.endswith(".kv"):
+                kv_files.append(os.path.join(root, file))
+    return kv_files
+
+
+def get_kv_files_paths():
+    """
+    Given the folders on WATCHED_FOLDERS and WATCHED_FOLDERS_RECURSIVELY,
+    returns a list of all the kv files paths
+    """
+    KV_FILES = []
+
+    for folder in config.WATCHED_FOLDERS:
+        for file_name in os.listdir(folder):
+            if file_name.endswith(".kv"):
+                KV_FILES.append(os.path.join(base_dir, f"{folder}/{file_name}"))
+
+    for folder in config.WATCHED_FOLDERS_RECURSIVELY:
+        for file_name in find_kv_files_in_folder(folder):
+            KV_FILES.append(file_name)
+
+    # Removing duplicates
+    KV_FILES = list(set(KV_FILES))
+
+    return KV_FILES


### PR DESCRIPTION
update to make kivy-reloader work with pyinstaller.
What you have to do (using beautifulapp setup as example: https://kivyschool.com/kivy-reloader/windows/setup-and-how-to-use/#advanced-example):

1: change kivy_reloader.app import App to kivy.app import App
```import sys
if hasattr(sys, "_MEIPASS"):
    from kivy.app import App
else:
    from kivy_reloader.app import App
```

2: make sure filepaths are preserved in the pyinstaller.spec: (specifically note the datas line, I send beautifulapp to beautifulapp)

```
# -*- mode: python ; coding: utf-8 -*-
from kivy_deps import sdl2, glew

a = Analysis(
    ['main.py'],
    pathex=[],
    binaries=[],
    datas=[("beautifulapp", "beautifulapp")],
    hiddenimports=[],
    hookspath=[],
    hooksconfig={},
    runtime_hooks=[],
    excludes=[],
    noarchive=False,
    optimize=0,
)
pyz = PYZ(a.pure)

exe = EXE(
    pyz,
    a.scripts,
    a.binaries,
    a.datas,
    *[Tree(p) for p in (sdl2.dep_bins + glew.dep_bins)],
    name='HelloWorld',
    debug=False,
    bootloader_ignore_signals=False,
    strip=False,
    upx=True,
    upx_exclude=[],
    runtime_tmpdir=None,
    console=True,
    disable_windowed_traceback=False,
    argv_emulation=False,
    target_arch=None,
    codesign_identity=None,
    entitlements_file=None,
)

```
