### PR TITLE
Fix multi-device USB hot reload forwarding

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,12 +99,14 @@ Button:
     text: "Hello World"
 """
 
+
 class MainApp(App):
     def build(self):
         return Builder.load_string(kv)
 
+
 app = MainApp()
-trio.run(app.async_run, "trio")
+trio.run(app.async_run, 'trio')
 ```
 
 #### Advanced (recommended package structure)
@@ -138,7 +140,7 @@ import trio
 from hello_world import HelloWorldApp
 
 app = HelloWorldApp()
-trio.run(app.async_run, "trio")
+trio.run(app.async_run, 'trio')
 ```
 
 `hello_world/app.py`
@@ -146,6 +148,7 @@ trio.run(app.async_run, "trio")
 ```python
 from kivy_reloader.app import App
 from hello_world.screens.main_screen import MainScreen
+
 
 class HelloWorldApp(App):
     def build(self):
@@ -169,6 +172,7 @@ from kivy.uix.screenmanager import Screen
 from kivy_reloader.lang import Builder
 
 Builder.load_file(__file__)
+
 
 class MainScreen(Screen):
     pass

--- a/kivy_reloader/send_app_to_phone.py
+++ b/kivy_reloader/send_app_to_phone.py
@@ -165,7 +165,6 @@ async def send_app():  # noqa:PLR0914
     acked_count = 0
 
     for IP, port, serial, model in targets:
-
         client_socket = await connect_to_server(IP, port)
 
         if not client_socket:
@@ -253,8 +252,7 @@ async def send_app():  # noqa:PLR0914
 
         if ack_ok:
             print(
-                f'{green}ACK received from {model} '
-                f'({serial or IP}), {formatted_time}'
+                f'{green}ACK received from {model} ({serial or IP}), {formatted_time}'
             )
             acked_count += 1
         else:

--- a/kivy_reloader/send_app_to_phone.py
+++ b/kivy_reloader/send_app_to_phone.py
@@ -23,8 +23,8 @@ white = Fore.WHITE
 init(autoreset=True)
 
 
-async def connect_to_server(IP):
-    PORT = int(config.RELOADER_PORT)
+async def connect_to_server(IP, port=None):
+    PORT = int(port or config.RELOADER_PORT)
     timeout = 60  # Total time we are willing to wait for a success
     start_time = trio.current_time()
     UAC_count = 0
@@ -69,6 +69,26 @@ async def connect_to_server(IP):
         f'\n{red}Could not connect to {IP} after {attempt_count} attempts in  ({timeout}s)'
     )
     return None
+
+
+def build_usb_targets(devices, remote_port, host_ip, forward=adb_forward):
+    """Create uniquely forwarded host targets for USB-connected devices."""
+    targets = []
+    for index, device in enumerate(devices):
+        host_port = remote_port + index
+        result = forward(
+            host_port,
+            serial=device['serial'],
+            remote_port=remote_port,
+        )
+        if result != 0:
+            print(
+                f'{yellow}Could not forward port for '
+                f'{device["model"]} ({device["serial"]})'
+            )
+            continue
+        targets.append((host_ip, host_port, device['serial'], device['model']))
+    return targets
 
 
 def wsl_network_dead(timeout=1.0):
@@ -131,29 +151,28 @@ async def send_app():  # noqa:PLR0914
         return 1
 
     if config.STREAM_USING == 'USB':
-        PORT = config.RELOADER_PORT
+        remote_port = int(config.RELOADER_PORT)
         usb_devices = [d for d in devices if d['transport'] == 'usb']
-        for d in usb_devices:
-            adb_forward(PORT, serial=d['serial'])
         host_ip = get_adb_host_ip()
-        unique_physical = {(host_ip, d['model']) for d in usb_devices}
+        targets = build_usb_targets(usb_devices, remote_port, host_ip)
     else:
-        unique_physical = {
-            (d['wifi_ip'], d['model']) for d in devices if d['wifi_ip'] is not None
-        }
+        targets = [
+            (device['wifi_ip'], int(config.RELOADER_PORT), None, device['model'])
+            for device in devices
+            if device['wifi_ip'] is not None
+        ]
 
     acked_count = 0
 
-    for device in unique_physical:
-        IP = device[0]
+    for IP, port, serial, model in targets:
 
-        client_socket = await connect_to_server(IP)
+        client_socket = await connect_to_server(IP, port)
 
         if not client_socket:
-            print(f"{yellow}Couldn't connect to smartphone: {IP}")
+            print(f"{yellow}Couldn't connect to {model} ({serial or IP})")
             continue
 
-        print(f'{yellow} Phone connected successfully: {IP}')
+        print(f'{yellow} Phone connected successfully: {model} ({serial or IP})')
         print(f'\n{green}Sending app to smartphone...')
 
         zip_path = 'app_copy.zip'
@@ -207,7 +226,7 @@ async def send_app():  # noqa:PLR0914
         # 3. Wait for OK
         min_speed_bytes_per_sec = 0.5 * 1024 * 1024  # 1 MB/s
         timeout = (zip_size / min_speed_bytes_per_sec) + 30
-        print(f'{yellow}Waiting ({timeout} seconds) for ACK from smartphone {IP}...')
+        print(f'{yellow}Waiting ({timeout} seconds) for ACK from {model}...')
         ack_ok = False
 
         start_wait = trio.current_time()
@@ -233,10 +252,16 @@ async def send_app():  # noqa:PLR0914
         formatted_time = datetime.datetime.now().strftime('%m-%d %H:%M:%S.%f')[:-3]
 
         if ack_ok:
-            print(f'{green}ACK received from {IP}, {formatted_time}')
+            print(
+                f'{green}ACK received from {model} '
+                f'({serial or IP}), {formatted_time}'
+            )
             acked_count += 1
         else:
-            print(f'{yellow}No ACK received from {IP}, {formatted_time}')
+            print(
+                f'{yellow}No ACK received from {model} '
+                f'({serial or IP}), {formatted_time}'
+            )
 
         # Close socket gracefully
         try:
@@ -245,7 +270,7 @@ async def send_app():  # noqa:PLR0914
             pass
 
     print('\n')
-    print(yellow + f'Sent app to {len(unique_physical)} smartphone(s)')
+    print(yellow + f'Sent app to {len(targets)} device(s)')
     if acked_count:
         print(green + f'ACK confirmed on {acked_count} smartphone(s)')
     else:

--- a/kivy_reloader/utils.py
+++ b/kivy_reloader/utils.py
@@ -518,11 +518,25 @@ def _validate_wifi_ip_ifconfig(ip: str, interface: str, serial: str) -> Optional
     return None
 
 
-def adb_forward(port: int, serial: str = None) -> int:
+def adb_forward(port: int, serial: str = None, remote_port: int = None) -> int:
+    """Forward a host port to a device port.
+
+    The local host port may differ from the device-side port. This is
+    required when forwarding the same reloader port for multiple devices.
+    """
+    if remote_port is None:
+        remote_port = port
     if serial:
-        cmd = ['adb', '-s', serial, 'forward', f'tcp:{port}', f'tcp:{port}']
+        cmd = [
+            'adb',
+            '-s',
+            serial,
+            'forward',
+            f'tcp:{port}',
+            f'tcp:{remote_port}',
+        ]
     else:
-        cmd = ['adb', 'forward', f'tcp:{port}', f'tcp:{port}']
+        cmd = ['adb', 'forward', f'tcp:{port}', f'tcp:{remote_port}']
     logging.info(' '.join(cmd))
     try:
         result = subprocess.run(cmd, timeout=10, check=False)

--- a/tests/test_multi_device_forwarding.py
+++ b/tests/test_multi_device_forwarding.py
@@ -1,0 +1,56 @@
+from kivy_reloader.send_app_to_phone import build_usb_targets
+
+
+def test_usb_targets_use_unique_host_ports_for_each_device():
+    devices = [
+        {
+            'serial': 'phone-1',
+            'model': 'same_model',
+            'transport': 'usb',
+        },
+        {
+            'serial': 'phone-2',
+            'model': 'same_model',
+            'transport': 'usb',
+        },
+    ]
+    calls = []
+
+    def forward(host_port, serial, remote_port):
+        calls.append((host_port, serial, remote_port))
+        return 0
+
+    targets = build_usb_targets(
+        devices,
+        remote_port=8050,
+        host_ip='127.0.0.1',
+        forward=forward,
+    )
+
+    assert targets == [
+        ('127.0.0.1', 8050, 'phone-1', 'same_model'),
+        ('127.0.0.1', 8051, 'phone-2', 'same_model'),
+    ]
+    assert calls == [
+        (8050, 'phone-1', 8050),
+        (8051, 'phone-2', 8050),
+    ]
+
+
+def test_usb_targets_skip_devices_when_forwarding_fails():
+    devices = [
+        {'serial': 'phone-1', 'model': 'model-1', 'transport': 'usb'},
+        {'serial': 'phone-2', 'model': 'model-2', 'transport': 'usb'},
+    ]
+
+    def forward(host_port, serial, remote_port):
+        return 1 if serial == 'phone-1' else 0
+
+    targets = build_usb_targets(
+        devices,
+        remote_port=8050,
+        host_ip='127.0.0.1',
+        forward=forward,
+    )
+
+    assert targets == [('127.0.0.1', 8051, 'phone-2', 'model-2')]


### PR DESCRIPTION
Closes #87 

  ### Summary

  Fixes hot-reload delivery when multiple Android devices are connected over USB.

  ### Changes

  - Assigns a unique host-side TCP port to each USB device.
  - Preserves the Android-side reloader port.
  - Removes model-based deduplication so multiple devices of the same model are supported.
  - Includes the device serial and model in connection logs.
  - Skips devices whose ADB forwarding setup fails.
  - Adds regression tests for multi-device forwarding.

  ### Testing

  - Regression tests pass: 2 passed.
  - Verified manually with:
      -  My phone
      - Android emulator

  - Both devices successfully received hot-reload updates.