### PR TITLE
Support package-root Android module reloads

### DIFF
--- a/kivy_reloader/android_app.py
+++ b/kivy_reloader/android_app.py
@@ -48,7 +48,7 @@ from . import __version__
 from .base_app import BaseReloaderApp
 from .config import config
 from .tree_formatter import format_file_tree
-from .utils import get_kv_files_paths
+from .utils import get_kv_files_paths, module_name_for_file
 
 # Constants
 CTRL_R_KEYCODE = 114
@@ -465,7 +465,7 @@ class AndroidApp(BaseReloaderApp, KivyApp):
         Returns:
             The module object if successfully unloaded, None otherwise
         """
-        if module == 'main':
+        if module in {'main', '__main__'}:
             return None
 
         if module in sys.modules:
@@ -515,8 +515,9 @@ class AndroidApp(BaseReloaderApp, KivyApp):
             List of module objects that need to be reloaded
         """
         modules_to_reload = []
+        package_name = self.__module__.split('.', 1)[0]
         for filename in files:
-            module_name = os.path.relpath(filename).replace(os.path.sep, '.')[:-3]
+            module_name = module_name_for_file(filename, package_name)
             to_reload = self.unload_python_file(filename, module_name)
             if to_reload is not None:
                 modules_to_reload.append(to_reload)

--- a/kivy_reloader/android_app.py
+++ b/kivy_reloader/android_app.py
@@ -48,7 +48,11 @@ from . import __version__
 from .base_app import BaseReloaderApp
 from .config import config
 from .tree_formatter import format_file_tree
-from .utils import get_kv_files_paths, module_name_for_file
+from .utils import (
+    get_kv_files_paths,
+    include_dependent_modules,
+    module_name_for_file,
+)
 
 # Constants
 CTRL_R_KEYCODE = 114
@@ -522,6 +526,7 @@ class AndroidApp(BaseReloaderApp, KivyApp):
             if to_reload is not None:
                 modules_to_reload.append(to_reload)
 
+        modules_to_reload = include_dependent_modules(modules_to_reload, package_name)
         return modules_to_reload
 
     def unload_python_files_on_android(self):

--- a/kivy_reloader/android_app.py
+++ b/kivy_reloader/android_app.py
@@ -583,6 +583,13 @@ class AndroidApp(BaseReloaderApp, KivyApp):
             f'Reloader: Reloading {len(modules_to_reload)} modules '
             f'({MODULE_RELOAD_PASSES} passes)'
         )
+        Logger.info(
+            'Reloader: Modules selected: '
+            + ', '.join(
+                getattr(module, '__name__', repr(module))
+                for module in modules_to_reload
+            )
+        )
         for pass_num in range(MODULE_RELOAD_PASSES):
             for module in modules_to_reload:
                 # importlib.reload requires sys.modules[spec.name] to be the exact

--- a/kivy_reloader/utils.py
+++ b/kivy_reloader/utils.py
@@ -1,4 +1,5 @@
 import base64
+import importlib.util
 import ipaddress
 import logging
 import os
@@ -6,6 +7,7 @@ import platform
 import re
 import socket
 import subprocess
+import sys
 import time
 from fnmatch import fnmatch
 from typing import Optional
@@ -31,6 +33,72 @@ logging.basicConfig(
     format='%(asctime)s - %(levelname)s - %(message)s',
 )
 base_dir = os.getcwd()
+
+
+def _module_file_matches(module_file, source_file):
+    """Return whether an imported module belongs to a source file."""
+    try:
+        module_path = os.path.realpath(module_file)
+        source_path = os.path.realpath(source_file)
+        if module_path == source_path:
+            return True
+
+        # A byte-compiled module may expose its cache path through
+        # ``__file__``. Resolve it back to the corresponding source path.
+        if module_path.endswith(('.pyc', '.pyo')):
+            try:
+                return (
+                    os.path.realpath(importlib.util.source_from_cache(module_path))
+                    == source_path
+                )
+            except (ImportError, ValueError):
+                return False
+    except (AttributeError, OSError, TypeError):
+        return False
+
+    return False
+
+
+def module_name_for_file(filename, package_name=None):
+    """Resolve a project file to the name Python used to import it.
+
+    Buildozer normally places the project root on ``sys.path``. ksproject can
+    instead execute a package entry point from inside the package directory.
+    In that layout ``uix/shader.py`` is still imported as
+    ``baby_lights.uix.shader``. Matching ``module.__file__`` supports both
+    layouts without making assumptions about the application package name.
+    """
+    source_file = filename
+    if not os.path.isabs(source_file):
+        source_file = os.path.join(os.getcwd(), source_file)
+
+    for module_name, module in list(sys.modules.items()):
+        module_file = getattr(module, '__file__', None)
+        if module_file and _module_file_matches(module_file, source_file):
+            return module_name
+
+    relative_path = os.path.relpath(filename)
+    module_name = relative_path.replace(os.path.sep, '.')
+    if module_name.endswith('.py'):
+        module_name = module_name[:-3]
+    if module_name.endswith('.__init__'):
+        module_name = module_name[:-9]
+
+    # Preserve the existing behavior when the path already corresponds to an
+    # imported module, and support package-root execution as a fallback if the
+    # module's __file__ cannot be matched (for example, on a bytecode-only
+    # deployment).
+    if module_name in sys.modules:
+        return module_name
+
+    if package_name:
+        if module_name == '__init__':
+            return package_name
+        package_module_name = f'{package_name}.{module_name}'
+        if package_module_name in sys.modules:
+            return package_module_name
+
+    return module_name
 
 
 def get_auto_reloader_paths():

--- a/kivy_reloader/utils.py
+++ b/kivy_reloader/utils.py
@@ -101,6 +101,44 @@ def module_name_for_file(filename, package_name=None):
     return module_name
 
 
+def include_dependent_modules(modules, package_name):
+    """Include app modules that still reference reloaded module objects.
+
+    ``importlib.reload`` updates a module in place, but names imported with
+    ``from module import Name`` remain bound to the old class or function in
+    the importing module. Find those modules so the caller can reload them as
+    well. Restrict the search to the application package to avoid reloading
+    unrelated third-party modules.
+    """
+    selected = list(modules)
+    selected_ids = {id(module) for module in selected}
+    dependency_names = {module.__name__ for module in selected}
+
+    changed = True
+    while changed:
+        changed = False
+        for module_name, module in list(sys.modules.items()):
+            if module is None or id(module) in selected_ids:
+                continue
+            if module_name != package_name and not module_name.startswith(
+                f'{package_name}.'
+            ):
+                continue
+
+            references_dependency = any(
+                getattr(value, '__module__', None) in dependency_names
+                or any(value is dependency for dependency in selected)
+                for value in vars(module).values()
+            )
+            if references_dependency:
+                selected.append(module)
+                selected_ids.add(id(module))
+                dependency_names.add(module_name)
+                changed = True
+
+    return selected
+
+
 def get_auto_reloader_paths():
     """
     Returns a list of paths to watch for changes,

--- a/tests/test_android_module_resolution.py
+++ b/tests/test_android_module_resolution.py
@@ -1,0 +1,36 @@
+import sys
+from types import ModuleType
+
+from kivy_reloader.utils import module_name_for_file
+
+
+def test_resolves_project_root_layout(monkeypatch, tmp_path):
+    source_file = tmp_path / 'baby_lights' / 'uix' / 'shader.py'
+    source_file.parent.mkdir(parents=True)
+    source_file.touch()
+
+    module = ModuleType('baby_lights.uix.shader')
+    module.__file__ = str(source_file)
+    monkeypatch.setitem(sys.modules, 'baby_lights.uix.shader', module)
+    monkeypatch.chdir(tmp_path)
+
+    assert (
+        module_name_for_file('baby_lights/uix/shader.py', 'baby_lights')
+        == 'baby_lights.uix.shader'
+    )
+
+
+def test_resolves_package_root_layout(monkeypatch, tmp_path):
+    package_root = tmp_path / 'site-packages' / 'baby_lights'
+    source_file = package_root / 'uix' / 'shader.py'
+    source_file.parent.mkdir(parents=True)
+    source_file.touch()
+
+    module = ModuleType('baby_lights.uix.shader')
+    module.__file__ = str(source_file)
+    monkeypatch.setitem(sys.modules, 'baby_lights.uix.shader', module)
+    monkeypatch.chdir(package_root)
+
+    assert (
+        module_name_for_file('uix/shader.py', 'baby_lights') == 'baby_lights.uix.shader'
+    )

--- a/tests/test_android_module_resolution.py
+++ b/tests/test_android_module_resolution.py
@@ -1,7 +1,10 @@
 import sys
 from types import ModuleType
 
-from kivy_reloader.utils import module_name_for_file
+from kivy_reloader.utils import (
+    include_dependent_modules,
+    module_name_for_file,
+)
 
 
 def test_resolves_project_root_layout(monkeypatch, tmp_path):
@@ -31,6 +34,27 @@ def test_resolves_package_root_layout(monkeypatch, tmp_path):
     monkeypatch.setitem(sys.modules, 'baby_lights.uix.shader', module)
     monkeypatch.chdir(package_root)
 
-    assert (
-        module_name_for_file('uix/shader.py', 'baby_lights') == 'baby_lights.uix.shader'
+    assert module_name_for_file('uix/shader.py', 'baby_lights') == (
+        'baby_lights.uix.shader'
     )
+
+
+def test_includes_modules_with_from_import_references(monkeypatch):
+    changed_module = ModuleType('baby_lights.uix.shader')
+    dependent_module = ModuleType('baby_lights.screens.shader_screen')
+    unrelated_module = ModuleType('other_package.screen')
+    shader_canvas = type(
+        'ShaderCanvas',
+        (),
+        {'__module__': 'baby_lights.uix.shader'},
+    )
+    dependent_module.ShaderCanvas = shader_canvas
+    unrelated_module.ShaderCanvas = shader_canvas
+
+    monkeypatch.setitem(sys.modules, changed_module.__name__, changed_module)
+    monkeypatch.setitem(sys.modules, dependent_module.__name__, dependent_module)
+    monkeypatch.setitem(sys.modules, unrelated_module.__name__, unrelated_module)
+
+    modules = include_dependent_modules([changed_module], 'baby_lights')
+
+    assert modules == [changed_module, dependent_module]


### PR DESCRIPTION
## Summary

  Fix Android hot reload for applications deployed with a package-root layout,
  such as ksproject projects.

  ## Changes

  - Resolve changed Python files using the modules already loaded in `sys.modules`.
  - Support both traditional project-root imports and package-root imports.
  - Reload modules that imported changed classes/functions with `from ... import ...`.
  - Log the module names selected for reload diagnostics.

  This fixes cases where `uix/shader.py` changes were transferred correctly but
  the running application continued using an old imported class.

  ## Validation

  - 5 tests passed.
  - Ruff check passed.
  - Ruff format check passed.
  - Tested on the Baby Lights Android phone.